### PR TITLE
Add option to ignore CRC checking

### DIFF
--- a/LLA/src/SENTAnalyzer.cpp
+++ b/LLA/src/SENTAnalyzer.cpp
@@ -165,9 +165,13 @@ void SENTAnalyzer::beginPulseDetected()
 {
 	if( framelist.size() == number_of_nibbles )
 	{
-		U8 calculated_crc = CalculateCRC();
-		U8 read_crc = framelist.at(crc_nibble_number).mData1;
-		bool crc_correct = read_crc == calculated_crc;
+          U8 read_crc = framelist.at(crc_nibble_number).mData1;
+          U8 calculated_crc = read_crc;
+          bool crc_correct = true;
+          if(!mSettings->ignoreCRC){
+		     U8 calculated_crc = CalculateCRC();
+		     crc_correct = read_crc == calculated_crc;
+          }
 		for(std::vector<Frame>::iterator it = framelist.begin(); it != framelist.end(); it++) {
 			if(!crc_correct && (it->mType == CRCNibble)) {
 				addErrorFrame(read_crc, calculated_crc, it->mStartingSampleInclusive, it->mEndingSampleInclusive, CrcError);

--- a/LLA/src/SENTAnalyzerSettings.cpp
+++ b/LLA/src/SENTAnalyzerSettings.cpp
@@ -9,6 +9,7 @@ SENTAnalyzerSettings::SENTAnalyzerSettings()
 	tick_time_us(3),
 	pausePulseEnabled(true),
 	spc(false),
+     ignoreCRC(false),
 	legacyCRC(false),
 	numberOfDataNibbles(6),
 	SCGeneration(SCGenerationOptions::Short)
@@ -37,6 +38,10 @@ SENTAnalyzerSettings::SENTAnalyzerSettings()
 	pausePulseInterface->SetTitleAndTooltip( "Pause pulse", "Specify whether pause pulse is enabled or not" );
 	pausePulseInterface->SetValue(pausePulseEnabled);
 
+	ignoreCRCInterface.reset( new AnalyzerSettingInterfaceBool() );
+	ignoreCRCInterface->SetTitleAndTooltip( "Ignore CRC", "Specify whether the crc should be done or not" );
+	ignoreCRCInterface->SetValue(ignoreCRC);
+
 	legacyCRCInterface.reset( new AnalyzerSettingInterfaceBool() );
 	legacyCRCInterface->SetTitleAndTooltip( "Legacy CRC", "Specify whether the legacy crc calculation should be used or not" );
 	legacyCRCInterface->SetValue(legacyCRC);
@@ -46,6 +51,7 @@ SENTAnalyzerSettings::SENTAnalyzerSettings()
 	AddInterface( dataNibblesInterface.get() );
 	AddInterface( spcInterface.get() );
 	AddInterface( pausePulseInterface.get() );
+     AddInterface( ignoreCRCInterface.get() );
 	AddInterface( legacyCRCInterface.get() );
 
 	// Generation tools //
@@ -91,6 +97,7 @@ bool SENTAnalyzerSettings::SetSettingsFromInterfaces()
 
 	numberOfDataNibbles = dataNibblesInterface->GetInteger();
 	legacyCRC = legacyCRCInterface->GetValue();
+     ignoreCRC = ignoreCRCInterface->GetValue();
 
 	#ifdef GENERATION_TOOLS
 	SCGeneration = (SCGenerationOptions)SCGenerationInterface->GetNumber();
@@ -114,6 +121,7 @@ void SENTAnalyzerSettings::UpdateInterfacesFromSettings()
 	legacyCRCInterface->SetValue(spc);
 	pausePulseInterface->SetValue(pausePulseEnabled);
 	legacyCRCInterface->SetValue(legacyCRC);
+     ignoreCRCInterface->SetValue(ignoreCRC);
 }
 
 void SENTAnalyzerSettings::LoadSettings( const char* settings )

--- a/LLA/src/SENTAnalyzerSettings.h
+++ b/LLA/src/SENTAnalyzerSettings.h
@@ -23,6 +23,7 @@ public:
 	bool pausePulseEnabled;
 	U32 numberOfDataNibbles;
 	bool spc;
+     bool ignoreCRC;
 	bool legacyCRC;
 
 	SCGenerationOptions SCGeneration;
@@ -33,6 +34,7 @@ protected:
 	std::unique_ptr< AnalyzerSettingInterfaceBool >		   pausePulseInterface;
 	std::unique_ptr< AnalyzerSettingInterfaceInteger >	   dataNibblesInterface;
 	std::unique_ptr< AnalyzerSettingInterfaceBool >		   spcInterface;
+     std::unique_ptr< AnalyzerSettingInterfaceBool >        ignoreCRCInterface;
 	std::unique_ptr< AnalyzerSettingInterfaceBool >        legacyCRCInterface;
 	std::unique_ptr< AnalyzerSettingInterfaceNumberList >  SCGenerationInterface;
 };


### PR DESCRIPTION
New devices are starting to implement a new type of CRC checking, do have another type of crc polynomial or seed, and do include or exclude the status nibble. As to analyze this devices, it is better to implement a HLA, that performs the CRC checking and interpretation of the data transmited, I have included a bool that lets us deactivate the CRC checking when not needed (It gets shown as a correct CRC, maybe the correct way would be to show it as another fc_data ?)